### PR TITLE
Fix compilation issues in Ubuntu 24.04

### DIFF
--- a/performance_test_factory/src/names_utilities.cpp
+++ b/performance_test_factory/src/names_utilities.cpp
@@ -10,6 +10,7 @@
 #include <regex>
 #include <sstream>
 #include <string>
+#include <iterator>
 
 #include "performance_test_factory/names_utilities.hpp"
 


### PR DESCRIPTION
In Ubuntu 24.04, colcon was raising compilation errors due to a missing header. This PR fixes that.
